### PR TITLE
Fixing imagePullSecrets postgres

### DIFF
--- a/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/charts/postgresql/templates/statefulset-slaves.yaml
@@ -43,8 +43,10 @@ spec:
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
       {{- end }}
-{{- include "postgresql.imagePullSecrets" . | indent 6 }}
-      {{- if .Values.slave.nodeSelector }}
+    {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}      {{- if .Values.slave.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.slave.nodeSelector | indent 8 }}
       {{- end }}

--- a/charts/postgresql/templates/statefulset.yaml
+++ b/charts/postgresql/templates/statefulset.yaml
@@ -47,7 +47,10 @@ spec:
       {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
       {{- end }}
-{{- include "postgresql.imagePullSecrets" . | indent 6 }}
+    {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       {{- if .Values.master.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.master.nodeSelector | indent 8 }}


### PR DESCRIPTION
Fixing format global

```
          app: rudderstack-postgresql
          chart: postgresql-7.7.2
          release: "rudderstack"
          heritage: "Helm"
          role: master
      spec:      
+       imagePullSecrets:
+         - name: map[name:evermos-docker]
        affinity:
          nodeAffinity:
            requiredDuringSchedulingIgnoredDuringExecution:
              nodeSelectorTerms:
```
to this 
```
+     spec:
+       imagePullSecrets:
+         - name: evermos-docker
        affinity:
          nodeAffinity:
```